### PR TITLE
ci: run sonar on master

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -242,4 +242,10 @@ jobs:
       - name: Analyze with coverage
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar --no-configuration-cache --no-parallel --no-daemon
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == "master" ]]; then
+            ./gradlew sonar --no-configuration-cache --no-parallel --no-daemon \
+              -Dsonar.branch.name=master
+          else
+            ./gradlew sonar --no-configuration-cache --no-parallel --no-daemon
+          fi


### PR DESCRIPTION
Modified the CI configuration to run Sonar analysis with a specific branch name when on the master branch. This ensures that the analysis is correctly attributed to the master branch, improving clarity in code quality reports.

## Checklist

- [x] Check code formatting
- [x] Run Android tests
- [x] Run Sonar analysis
